### PR TITLE
BUGFIX: add package executable to config

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+executables:
+  svg_to_paint:
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
This is fixing the error:
`command not found: svg_to_paint`

Reason:
the executable is not added to pub system cache

According to docs, this is needed in order to expose the packages executable: 
https://dart.dev/tools/pub/cmd/pub-global#configuring-package-executables
